### PR TITLE
chore: add dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
## Summary
- add a 3-day Dependabot cooldown to all configured ecosystems

## Testing
- not run (Dependabot config only)
