### PR TITLE
Repo maintenance: pin deps, harden entrypoint, update Docker base

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,10 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 3
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,6 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Linting Dockerfile
-        uses: brpaz/hadolint-action@f49a60108f34b589e16e00be852f810e8ddb2484 # master
+        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
         with:
           dockerfile: 'Dockerfile'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-# hadolint ignore=DL3007
-FROM alpine:latest
+FROM alpine:3.24
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache curl
@@ -7,7 +6,6 @@ RUN apk add --no-cache curl
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
 # Install rootly-cli from GitHub releases
-ARG ROOTLY_CLI_VERSION=latest
 RUN curl -fsSL "https://github.com/rootlyhq/rootly-cli/releases/latest/download/rootly-cli_$(curl -fsSL https://api.github.com/repos/rootlyhq/rootly-cli/releases/latest | grep '"tag_name"' | sed 's/.*"v\(.*\)".*/\1/')_linux_amd64.tar.gz" \
     | tar -xz -C /usr/local/bin rootly \
     && chmod +x /usr/local/bin/rootly

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ jobs:
   pulse:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: make deploy
       - name: rootly-pulse
         uses: rootlyhq/pulse-action@master

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,6 @@
 #!/bin/sh
 set -e
 
-# Map GitHub Action inputs to rootly-cli flags
-# GitHub Actions passes inputs as INPUT_<NAME> environment variables
-
 if [ -z "${INPUT_API_KEY}" ]; then
   echo "Error: api_key input is required" >&2
   exit 1
@@ -16,31 +13,26 @@ fi
 
 export ROOTLY_API_KEY="${INPUT_API_KEY}"
 
-# Build the command
-CMD="rootly pulse create"
+set -- rootly pulse create
 
-# Add optional flags
 if [ -n "${INPUT_ENVIRONMENTS}" ]; then
-  CMD="${CMD} --environments=\"${INPUT_ENVIRONMENTS}\""
+  set -- "$@" --environments="${INPUT_ENVIRONMENTS}"
 fi
 
 if [ -n "${INPUT_SERVICES}" ]; then
-  CMD="${CMD} --services=\"${INPUT_SERVICES}\""
+  set -- "$@" --services="${INPUT_SERVICES}"
 fi
 
 if [ -n "${INPUT_LABELS}" ]; then
-  CMD="${CMD} --labels=\"${INPUT_LABELS}\""
+  set -- "$@" --labels="${INPUT_LABELS}"
 fi
 
 if [ -n "${INPUT_SOURCE}" ]; then
-  CMD="${CMD} --source=\"${INPUT_SOURCE}\""
+  set -- "$@" --source="${INPUT_SOURCE}"
 fi
 
 if [ -n "${INPUT_REFS}" ]; then
-  CMD="${CMD} --refs=\"${INPUT_REFS}\""
+  set -- "$@" --refs="${INPUT_REFS}"
 fi
 
-# Summary as positional argument
-CMD="${CMD} \"${INPUT_SUMMARY}\""
-
-eval ${CMD}
+exec "$@" "${INPUT_SUMMARY}"


### PR DESCRIPTION
## Summary

- **Docker**: Pin `alpine:latest` → `alpine:3.24`, remove `DL3007` hadolint ignore, remove unused `ROOTLY_CLI_VERSION` ARG
- **Actions**: Bump `actions/checkout` v6 → v7, replace unmaintained `brpaz/hadolint-action` with official `hadolint/hadolint-action` v3.3.0 — all SHA-pinned
- **Dependabot**: Add `docker` ecosystem for Alpine base image updates, add cooldown config
- **entrypoint.sh**: Replace `eval`-based command building with `set`/`exec` for safer argument handling (avoids shell injection if inputs contain special chars)
- **README**: Update example to `actions/checkout@v7`

## Test plan
- [ ] CI build workflow passes (docker build)
- [ ] CI lint workflow passes (hadolint)
- [ ] Verify pulse action still works with a test pulse